### PR TITLE
various chart improvments

### DIFF
--- a/.github/workflows/chart-docs.yaml
+++ b/.github/workflows/chart-docs.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Generate Helm Documentation
         id: helmdocs
-        run: docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.11.0
+        run: docker run --rm --volume "$(pwd):/helm-docs" -u $(id -u) jnorwood/helm-docs:v1.12.0
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/chart-docs.yaml
+++ b/.github/workflows/chart-docs.yaml
@@ -1,11 +1,9 @@
 name: Update Charts docs
 
 on:
-  workflow_dispatch:
   push:
     branches:
-      - main
-      - prod
+      - "main"
     paths:
       - "charts/**"
 

--- a/.github/workflows/chart-docs.yaml
+++ b/.github/workflows/chart-docs.yaml
@@ -1,9 +1,11 @@
 name: Update Charts docs
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - "main"
+      - main
+      - prod
     paths:
       - "charts/**"
 

--- a/.github/workflows/chart-docs.yaml
+++ b/.github/workflows/chart-docs.yaml
@@ -1,6 +1,7 @@
 name: Update Charts docs
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,6 +1,7 @@
 name: Release Charts
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -1,11 +1,9 @@
 name: Release Charts
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
-      - prod
     paths:
       - "charts/**"
 

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - prod
     paths:
       - "charts/**"
 

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -24,9 +24,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v5
         with:
-          version: v3.10.0
+          version: v5.0.0
 
       - name: Add repositories
         run: |
@@ -35,7 +35,7 @@ jobs:
           done
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true

--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: v5.0.0
+          version: v4.2.2
 
       - name: Add repositories
         run: |

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
+# Thumbor Helm Chart
+
 ## ⚠️ Warning
+
 This project is still under development. At the moment, we don't recommend usage in production.
 
 ## 🌈 Goal
+
 This project aims to provide easy-to-use Helm charts for [Thumbor](https://github.com/thumbor/thumbor) and its components.
 Currently, the only Helm chart available is for a vanilla Thumbor deployment.
 
 ## ⚙️ Usage
+
 ```bash
 helm repo add thumbor https://thumbor.github.io/helm
 helm install thumbor thumbor/thumbor
 ```
 
 You can find the chart documentation under the chart folder:
-- [Thumbor](https://github.com/thumbor/helm/tree/main/charts/thumbor)
 
+- [Thumbor](https://github.com/thumbor/helm/tree/main/charts/thumbor)

--- a/charts/thumbor/Chart.lock
+++ b/charts/thumbor/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.1
+  version: 2.14.1
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.3.14
-digest: sha256:5202ce038c813cc0d94a3d72fd59dd855852f55040002a5fae51115c81a00893
-generated: "2022-12-12T01:28:53.673294+01:00"
+  version: 17.3.18
+digest: sha256:f328851324e68e5b7c171e543313f2c4d8a28c966657c2b05c984893cc45739e
+generated: "2024-02-12T17:39:01.256040449+01:00"

--- a/charts/thumbor/Chart.lock
+++ b/charts/thumbor/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.14.1
+  version: 2.15.1
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 17.3.18
-digest: sha256:f328851324e68e5b7c171e543313f2c4d8a28c966657c2b05c984893cc45739e
-generated: "2024-02-12T17:39:01.256040449+01:00"
+digest: sha256:f381af6391f3102a77eb1c03c37f22bda229ff17daa5644f4a5dd2a9a9902305
+generated: "2024-02-14T12:14:13.356461414+01:00"

--- a/charts/thumbor/Chart.lock
+++ b/charts/thumbor/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.15.1
+  version: 2.40.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 17.3.18
-digest: sha256:f381af6391f3102a77eb1c03c37f22bda229ff17daa5644f4a5dd2a9a9902305
-generated: "2024-02-14T12:14:13.356461414+01:00"
+  version: 27.0.10
+digest: sha256:a97f2b873b488dbb61146c9e9f1a1ccf4a756f652f26bd8c2c64782a0629fa2a
+generated: "2026-06-22T11:40:44.398190914+02:00"

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 0.1.0
+version: 1.0.0
 appVersion: "7.1.1"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -18,4 +18,4 @@ dependencies:
   - name: redis
     version: 17.3.x
     repository: https://charts.bitnami.com/bitnami
-    condition: thumbor_config.queued_detector.enable_redis
+    condition: remotecv.enabled

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -18,4 +18,4 @@ dependencies:
   - name: redis
     version: 17.3.x
     repository: https://charts.bitnami.com/bitnami
-    condition: remotecv.enabled
+    condition: remotecv.installRedis

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "7.1.1"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.0.4
-appVersion: "7.1.1"
+version: 1.1.0
+appVersion: "7.7.5"
 home: http://www.thumbor.org/
 sources:
   - https://github.com/thumbor/helm/tree/main/charts/thumbor

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: "7.1.1"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "7.1.1"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "7.1.1"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.2.0
+version: 2.0.0
 appVersion: "7.8.0"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -3,7 +3,7 @@ name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
 version: 1.1.0
-appVersion: "7.7.5"
+appVersion: "7.7.7"
 home: http://www.thumbor.org/
 sources:
   - https://github.com/thumbor/helm/tree/main/charts/thumbor

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.1.1
-appVersion: "7.7.7"
+version: 1.2.0
+appVersion: "7.8.0"
 home: http://www.thumbor.org/
 sources:
   - https://github.com/thumbor/helm/tree/main/charts/thumbor
@@ -16,6 +16,6 @@ dependencies:
     version: 2.x.x
     repository: https://charts.bitnami.com/bitnami
   - name: redis
-    version: 17.3.x
+    version: 27.0.x
     repository: https://charts.bitnami.com/bitnami
     condition: remotecv.installRedis

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 1.1.0
+version: 1.1.1
 appVersion: "7.7.7"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/Chart.yaml
+++ b/charts/thumbor/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: thumbor
 description: Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "7.8.0"
 home: http://www.thumbor.org/
 sources:

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
 
-Thumbor(<https://github.com/thumbor/thumbor>) Helm chart.
+Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 
 **Homepage:** <http://www.thumbor.org/>
 
@@ -20,11 +20,10 @@ Thumbor(<https://github.com/thumbor/thumbor>) Helm chart.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| <https://charts.bitnami.com/bitnami> | common | 2.x.x |
-| <https://charts.bitnami.com/bitnami> | redis | 17.3.x |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
+| https://charts.bitnami.com/bitnami | redis | 17.3.x |
 
 ## ⚙️ Usage
-
 ```bash
 helm repo add thumbor https://thumbor.github.io/helm
 helm install thumbor thumbor/thumbor
@@ -47,7 +46,7 @@ helm install thumbor thumbor/thumbor
 {}
 </pre>
 </td>
-			<td></td>
+			<td>define affinities for the thumbor pod</td>
 		</tr>
 		<tr>
 			<td>autoscaling.enabled</td>
@@ -56,7 +55,7 @@ helm install thumbor thumbor/thumbor
 false
 </pre>
 </td>
-			<td></td>
+			<td>enable autoscaling via the HorizontalPodAutoscaler for the thumbor deployment Your Cluster needs to support this!</td>
 		</tr>
 		<tr>
 			<td>autoscaling.maxReplicas</td>
@@ -86,6 +85,15 @@ false
 			<td></td>
 		</tr>
 		<tr>
+			<td>env</td>
+			<td>object</td>
+			<td><pre lang="json">
+{}
+</pre>
+</td>
+			<td>environment variables for the thumbor pod</td>
+		</tr>
+		<tr>
 			<td>fullnameOverride</td>
 			<td>string</td>
 			<td><pre lang="json">
@@ -101,7 +109,7 @@ false
 "IfNotPresent"
 </pre>
 </td>
-			<td></td>
+			<td>override pullPolicy for thumbor image</td>
 		</tr>
 		<tr>
 			<td>image.repository</td>
@@ -110,7 +118,7 @@ false
 "ghcr.io/thumbor/thumbor"
 </pre>
 </td>
-			<td></td>
+			<td>Overrides the image</td>
 		</tr>
 		<tr>
 			<td>image.tag</td>
@@ -119,7 +127,7 @@ false
 "7-py-3.10"
 </pre>
 </td>
-			<td></td>
+			<td>Overrides the image tag whose default is the chart appVersion.</td>
 		</tr>
 		<tr>
 			<td>imagePullSecrets</td>
@@ -128,7 +136,7 @@ false
 []
 </pre>
 </td>
-			<td></td>
+			<td>if the used image is not public</td>
 		</tr>
 		<tr>
 			<td>ingress.annotations</td>
@@ -137,7 +145,7 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>ingress annotations</td>
 		</tr>
 		<tr>
 			<td>ingress.className</td>
@@ -146,7 +154,7 @@ false
 ""
 </pre>
 </td>
-			<td></td>
+			<td>specify ingress class or leave blank for the default ingress class</td>
 		</tr>
 		<tr>
 			<td>ingress.enabled</td>
@@ -155,7 +163,7 @@ false
 false
 </pre>
 </td>
-			<td></td>
+			<td>enable ingress</td>
 		</tr>
 		<tr>
 			<td>ingress.hosts[0].host</td>
@@ -182,7 +190,7 @@ false
 "ImplementationSpecific"
 </pre>
 </td>
-			<td></td>
+			<td>if errors occure use Prefix</td>
 		</tr>
 		<tr>
 			<td>ingress.tls</td>
@@ -209,7 +217,7 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>deploy thumbor to a specific node</td>
 		</tr>
 		<tr>
 			<td>podAnnotations</td>
@@ -218,7 +226,7 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>optional pod Annotations</td>
 		</tr>
 		<tr>
 			<td>podSecurityContext</td>
@@ -227,7 +235,7 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>optional podSecurityContext settings</td>
 		</tr>
 		<tr>
 			<td>redis.image.registry</td>
@@ -257,13 +265,22 @@ false
 			<td></td>
 		</tr>
 		<tr>
+			<td>redis.replica.replicaCount</td>
+			<td>int</td>
+			<td><pre lang="json">
+0
+</pre>
+</td>
+			<td>increase this option if you need replicas</td>
+		</tr>
+		<tr>
 			<td>remotecv.affinity</td>
 			<td>object</td>
 			<td><pre lang="json">
 {}
 </pre>
 </td>
-			<td></td>
+			<td>define affinities for the thumbor remotecv pod</td>
 		</tr>
 		<tr>
 			<td>remotecv.autoscaling.enabled</td>
@@ -272,7 +289,7 @@ false
 false
 </pre>
 </td>
-			<td></td>
+			<td>enable autoscaling via the HorizontalPodAutoscaler for the remotecv deployment Your Cluster needs to support this!</td>
 		</tr>
 		<tr>
 			<td>remotecv.autoscaling.maxReplicas</td>
@@ -302,6 +319,69 @@ false
 			<td></td>
 		</tr>
 		<tr>
+			<td>remotecv.enabled</td>
+			<td>bool</td>
+			<td><pre lang="json">
+true
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>remotecv.env.HTTP_SERVER_PORT</td>
+			<td>string</td>
+			<td><pre lang="json">
+"8080"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>remotecv.env.REDIS_HOST</td>
+			<td>string</td>
+			<td><pre lang="json">
+"thumbor-redis-master"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>remotecv.env.REDIS_PASSWORD.valueFrom.secretKeyRef.key</td>
+			<td>string</td>
+			<td><pre lang="json">
+"redis-password"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>remotecv.env.REDIS_PASSWORD.valueFrom.secretKeyRef.name</td>
+			<td>string</td>
+			<td><pre lang="json">
+"thumbor-redis"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>remotecv.env.REDIS_PORT</td>
+			<td>string</td>
+			<td><pre lang="json">
+"6379"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
+			<td>remotecv.env.WITH_HEALTHCHECK</td>
+			<td>string</td>
+			<td><pre lang="json">
+"1"
+</pre>
+</td>
+			<td></td>
+		</tr>
+		<tr>
 			<td>remotecv.image.pullPolicy</td>
 			<td>string</td>
 			<td><pre lang="json">
@@ -317,7 +397,7 @@ false
 "ghcr.io/thumbor/remotecv"
 </pre>
 </td>
-			<td></td>
+			<td>Overrides the remotecv image</td>
 		</tr>
 		<tr>
 			<td>remotecv.image.tag</td>
@@ -326,7 +406,16 @@ false
 "3-py-3.11"
 </pre>
 </td>
-			<td></td>
+			<td>Overrides the image tag whose default is the chart appVersion.</td>
+		</tr>
+		<tr>
+			<td>remotecv.installRedis</td>
+			<td>bool</td>
+			<td><pre lang="json">
+true
+</pre>
+</td>
+			<td>set this to false if you want to use an already existing redis server</td>
 		</tr>
 		<tr>
 			<td>remotecv.nodeSelector</td>
@@ -335,7 +424,7 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>deploy thumbor remotecv to a specific node</td>
 		</tr>
 		<tr>
 			<td>remotecv.podAnnotations</td>
@@ -344,7 +433,7 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>add podAnnotations tho the thumbor remotecv pod</td>
 		</tr>
 		<tr>
 			<td>remotecv.replicaCount</td>
@@ -353,7 +442,7 @@ false
 1
 </pre>
 </td>
-			<td></td>
+			<td>how many remotecv pod do you want</td>
 		</tr>
 		<tr>
 			<td>remotecv.resources</td>
@@ -371,7 +460,7 @@ false
 []
 </pre>
 </td>
-			<td></td>
+			<td>define tolerations for the thumbor remotecv pod</td>
 		</tr>
 		<tr>
 			<td>replicaCount</td>
@@ -380,7 +469,7 @@ false
 1
 </pre>
 </td>
-			<td></td>
+			<td>how many thumbor pods should be deployed</td>
 		</tr>
 		<tr>
 			<td>resources</td>
@@ -398,7 +487,7 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>securityContext for the thumbor container</td>
 		</tr>
 		<tr>
 			<td>service.port</td>
@@ -407,7 +496,7 @@ false
 80
 </pre>
 </td>
-			<td></td>
+			<td>Thumbor service port thumbor uses container Port 80</td>
 		</tr>
 		<tr>
 			<td>service.type</td>
@@ -416,7 +505,7 @@ false
 "ClusterIP"
 </pre>
 </td>
-			<td></td>
+			<td>Thumbor service type</td>
 		</tr>
 		<tr>
 			<td>serviceAccount.annotations</td>
@@ -425,16 +514,16 @@ false
 {}
 </pre>
 </td>
-			<td></td>
+			<td>Annotations to add to the service account</td>
 		</tr>
 		<tr>
 			<td>serviceAccount.create</td>
 			<td>bool</td>
 			<td><pre lang="json">
-true
+false
 </pre>
 </td>
-			<td></td>
+			<td>Specifies whether a service account should be created</td>
 		</tr>
 		<tr>
 			<td>serviceAccount.name</td>
@@ -443,43 +532,25 @@ true
 ""
 </pre>
 </td>
-			<td></td>
+			<td>The name of the service account to use. If not set and create is true, a name is generated using the fullname template</td>
 		</tr>
 		<tr>
-			<td>thumbor_config.content</td>
+			<td>thumbor_config</td>
 			<td>string</td>
 			<td><pre lang="json">
 "AUTO_WEBP = True\n"
 </pre>
 </td>
-			<td></td>
+			<td>configuration file for thumbor</td>
 		</tr>
 		<tr>
-			<td>thumbor_config.queued_detector.enable_redis</td>
-			<td>bool</td>
-			<td><pre lang="json">
-true
-</pre>
-</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>thumbor_config.queued_detector.enabled</td>
-			<td>bool</td>
-			<td><pre lang="json">
-true
-</pre>
-</td>
-			<td></td>
-		</tr>
-		<tr>
-			<td>thumbor_config_existing_secret</td>
+			<td>thumbor_existing_secret</td>
 			<td>string</td>
 			<td><pre lang="json">
 ""
 </pre>
 </td>
-			<td></td>
+			<td>if you have already an secret with the thumbor key</td>
 		</tr>
 		<tr>
 			<td>thumbor_key.manage</td>
@@ -497,10 +568,10 @@ true
 []
 </pre>
 </td>
-			<td></td>
+			<td>define tolerations for the thumbor pod</td>
 		</tr>
 	</tbody>
 </table>
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.12.0](https://github.com/norwoodj/helm-docs/releases/v1.12.0)

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
 
-Thumbor(https://github.com/thumbor/thumbor) Helm chart.
+Thumbor(<https://github.com/thumbor/thumbor>) Helm chart.
 
 **Homepage:** <http://www.thumbor.org/>
 
@@ -20,10 +20,11 @@ Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 2.x.x |
-| https://charts.bitnami.com/bitnami | redis | 17.3.x |
+| <https://charts.bitnami.com/bitnami> | common | 2.x.x |
+| <https://charts.bitnami.com/bitnami> | redis | 17.3.x |
 
 ## ⚙️ Usage
+
 ```bash
 helm repo add thumbor https://thumbor.github.io/helm
 helm install thumbor thumbor/thumbor

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.5](https://img.shields.io/badge/AppVersion-7.7.5-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 
@@ -124,7 +124,7 @@ false
 			<td>image.tag</td>
 			<td>string</td>
 			<td><pre lang="json">
-"7-py-3.10"
+"7.7.5-py-3.12"
 </pre>
 </td>
 			<td>Overrides the image tag whose default is the chart appVersion.</td>

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.1](https://img.shields.io/badge/AppVersion-7.1.1-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.7](https://img.shields.io/badge/AppVersion-7.7.7-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.7](https://img.shields.io/badge/AppVersion-7.7.7-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.7](https://img.shields.io/badge/AppVersion-7.7.7-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.8.0](https://img.shields.io/badge/AppVersion-7.8.0-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 
@@ -21,7 +21,7 @@ Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | common | 2.x.x |
-| https://charts.bitnami.com/bitnami | redis | 17.3.x |
+| https://charts.bitnami.com/bitnami | redis | 27.0.x |
 
 ## ⚙️ Usage
 ```bash
@@ -124,7 +124,7 @@ false
 			<td>image.tag</td>
 			<td>string</td>
 			<td><pre lang="json">
-"7.7.7-py-3.13"
+"7.8.0-py-3.14"
 </pre>
 </td>
 			<td>Overrides the image tag whose default is the chart appVersion.</td>

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.8.0](https://img.shields.io/badge/AppVersion-7.8.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.8.0](https://img.shields.io/badge/AppVersion-7.8.0-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.8.0](https://img.shields.io/badge/AppVersion-7.8.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.8.0](https://img.shields.io/badge/AppVersion-7.8.0-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 

--- a/charts/thumbor/README.md
+++ b/charts/thumbor/README.md
@@ -1,6 +1,6 @@
 # thumbor
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.5](https://img.shields.io/badge/AppVersion-7.7.5-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.7.7](https://img.shields.io/badge/AppVersion-7.7.7-informational?style=flat-square)
 
 Thumbor(https://github.com/thumbor/thumbor) Helm chart.
 
@@ -124,7 +124,7 @@ false
 			<td>image.tag</td>
 			<td>string</td>
 			<td><pre lang="json">
-"7.7.5-py-3.12"
+"7.7.7-py-3.13"
 </pre>
 </td>
 			<td>Overrides the image tag whose default is the chart appVersion.</td>

--- a/charts/thumbor/templates/_helpers.tpl
+++ b/charts/thumbor/templates/_helpers.tpl
@@ -65,25 +65,23 @@ Create the name of the service account to use
 Convert Key:Value to correct env var format
 */}}
 {{- define "thumbor.envVars" -}}
-    {{- with .Values.env -}}
-        # create a empty resulsts list
-        {{- $result := list -}}
-        # loop over .Values.env with $key and $value
-        {{- range $key, $value := . -}}
-            # If value is a map it probably will be valueFrom
-            {{- if kindIs "map" $value -}}
-                # make sure it is realy a valueFrom a secret
-                {{- if hasKey $value "valueFrom" -}}
-                    # append results list with the corret valueFrom format
-                    {{- $result = append $result (dict "name" $key "valueFrom" $value.valueFrom) -}}
-                {{- end -}}
-            {{- else -}}
-                # if it is not a map, convert the value to string and append the results
-                # with the expected env var dict
-                {{- $result = append $result (dict "name" $key "value" ($value | toString)) -}}
+    # create a empty resulsts list
+    {{- $result := list -}}
+    # loop over .Values.env with $key and $value
+    {{- range $key, $value := . -}}
+        # If value is a map it probably will be valueFrom
+        {{- if kindIs "map" $value -}}
+            # make sure it is realy a valueFrom a secret
+            {{- if hasKey $value "valueFrom" -}}
+                # append results list with the corret valueFrom format
+                {{- $result = append $result (dict "name" $key "valueFrom" $value.valueFrom) -}}
             {{- end -}}
+        {{- else -}}
+            # if it is not a map, convert the value to string and append the results
+            # with the expected env var dict
+            {{- $result = append $result (dict "name" $key "value" ($value | toString)) -}}
         {{- end -}}
-        # return result array as yaml dict under the key 'env'
-        {{- toYaml (dict "env" $result) | nindent 0 -}}
     {{- end -}}
+    # return result array as yaml dict under the key 'env'
+    {{- toYaml (dict "env" $result) | nindent 0 -}}
 {{- end -}}

--- a/charts/thumbor/templates/_helpers.tpl
+++ b/charts/thumbor/templates/_helpers.tpl
@@ -54,9 +54,36 @@
 Create the name of the service account to use
 */}}
 {{- define "thumbor.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "common.names.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
+    {{- if .Values.serviceAccount.create -}}
+        {{- default (include "common.names.fullname" .) .Values.serviceAccount.name -}}
+    {{- else -}}
+        {{- default "default" .Values.serviceAccount.name -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Convert Key:Value to correct env var format
+*/}}
+{{- define "thumbor.envVars" -}}
+    {{- with .Values.env -}}
+        # create a empty resulsts list
+        {{- $result := list -}}
+        # loop over .Values.env with $key and $value
+        {{- range $key, $value := . -}}
+            # If value is a map it probably will be valueFrom
+            {{- if kindIs "map" $value -}}
+                # make sure it is realy a valueFrom a secret
+                {{- if hasKey $value "valueFrom" -}}
+                    # append results list with the corret valueFrom format
+                    {{- $result = append $result (dict "name" $key "valueFrom" $value.valueFrom) -}}
+                {{- end -}}
+            {{- else -}}
+                # if it is not a map, convert the value to string and append the results
+                # with the expected env var dict
+                {{- $result = append $result (dict "name" $key "value" ($value | toString)) -}}
+            {{- end -}}
+        {{- end -}}
+        # return result array as yaml dict under the key 'env'
+        {{- toYaml (dict "env" $result) | nindent 0 -}}
+    {{- end -}}
+{{- end -}}

--- a/charts/thumbor/templates/configmap.yaml
+++ b/charts/thumbor/templates/configmap.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.thumbor_key.manage }}
+{{- if .Values.thumbor_config }}
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
@@ -9,5 +9,6 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
 data:
-  thumbor.key: {{ include "common.secrets.passwords.manage" (dict "secret" (include "common.names.fullname" .) "key" "thumbor.key" "providedValues" (list "thumbor_key.content" ) "context" $) }}
+  thumbor.conf: |-
+    {{- include "common.tplvalues.render" (dict "value" .Values.thumbor_config "context" $) | nindent 4 }}
 {{- end }}

--- a/charts/thumbor/templates/remotecv-deployment.yaml
+++ b/charts/thumbor/templates/remotecv-deployment.yaml
@@ -41,14 +41,18 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.remotecv.image.repository }}:{{ .Values.remotecv.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.remotecv.image.pullPolicy }}
+          # workaround, because normal env are not correctly read
+          # @see https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#use-environment-variables-to-define-arguments
           args:
-          - --host=thumbor-redis-master
-          - --port=6379
-          - --with-healthcheck
-          - --server-port=8080
+            - "--host=$(REDIS_HOST)"
+            - "--port=$(REDIS_PORT)"
+            - "--with-healthcheck"
+            - "--server-port=$(HTTP_SERVER_PORT)"
+            - "--password=$(REDIS_PASSWORD)"
+            - "-l=warning"
           {{- with .Values.remotecv.env }}
           env:
-            {{- get (fromYaml (include "thumbor.envVars" $)) "env" | toYaml | nindent 12 -}}
+            {{- get (fromYaml (include "thumbor.envVars" .)) "env" | toYaml | nindent 12 -}}
           {{- end }}
           ports:
             - name: http

--- a/charts/thumbor/templates/remotecv-deployment.yaml
+++ b/charts/thumbor/templates/remotecv-deployment.yaml
@@ -35,6 +35,21 @@ spec:
       serviceAccountName: {{ include "thumbor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.remotecv.env }}
+      initContainers:
+        - name: wait-for-redis
+          image: busybox
+          command:
+            - /bin/sh
+            - -c
+            - >
+              while [ $(echo -e "AUTH $REDIS_PASSWORD\r\nPING\r\n" | nc $REDIS_HOST $REDIS_PORT | grep -c "PONG") -ne 1 ]; do
+                echo "Waiting for Redis...";
+                sleep 1;
+              done
+          env:
+            {{- get (fromYaml (include "thumbor.envVars" .)) "env" | toYaml | nindent 12 -}}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/thumbor/templates/remotecv-deployment.yaml
+++ b/charts/thumbor/templates/remotecv-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.thumbor_config.queued_detector.enabled }}
+{{- if .Values.remotecv.enabled }}
 apiVersion:  {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:

--- a/charts/thumbor/templates/remotecv-deployment.yaml
+++ b/charts/thumbor/templates/remotecv-deployment.yaml
@@ -46,6 +46,10 @@ spec:
           - --port=6379
           - --with-healthcheck
           - --server-port=8080
+          {{- with .Values.remotecv.env }}
+          env:
+            {{- get (fromYaml (include "thumbor.envVars" $)) "env" | toYaml | nindent 12 -}}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/thumbor/templates/remotecv-deployment.yaml
+++ b/charts/thumbor/templates/remotecv-deployment.yaml
@@ -43,10 +43,10 @@ spec:
             - /bin/sh
             - -c
             - >
-              COUNT=0
+              COUNT=0;
               while [ $(echo -e "AUTH $REDIS_PASSWORD\r\nPING\r\n" | nc $REDIS_HOST $REDIS_PORT | grep -c "PONG") -ne 1 ]; do
                 if [[ $COUNT -ge 10 ]]; then
-                  echo "Waited to long restarting POD"
+                  echo "Waited to long restarting POD";
                   exit 1;
                 fi
 

--- a/charts/thumbor/templates/remotecv-deployment.yaml
+++ b/charts/thumbor/templates/remotecv-deployment.yaml
@@ -43,9 +43,16 @@ spec:
             - /bin/sh
             - -c
             - >
+              COUNT=0
               while [ $(echo -e "AUTH $REDIS_PASSWORD\r\nPING\r\n" | nc $REDIS_HOST $REDIS_PORT | grep -c "PONG") -ne 1 ]; do
+                if [[ $COUNT -ge 10 ]]; then
+                  echo "Waited to long restarting POD"
+                  exit 1;
+                fi
+
                 echo "Waiting for Redis...";
                 sleep 1;
+                ((COUNT++))
               done
           env:
             {{- get (fromYaml (include "thumbor.envVars" .)) "env" | toYaml | nindent 12 -}}

--- a/charts/thumbor/templates/remotecv-deployment.yaml
+++ b/charts/thumbor/templates/remotecv-deployment.yaml
@@ -52,7 +52,7 @@ spec:
 
                 echo "Waiting for Redis...";
                 sleep 1;
-                ((COUNT++))
+                COUNT=$((COUNT+1))
               done
           env:
             {{- get (fromYaml (include "thumbor.envVars" .)) "env" | toYaml | nindent 12 -}}

--- a/charts/thumbor/templates/thumbor-deployment.yaml
+++ b/charts/thumbor/templates/thumbor-deployment.yaml
@@ -46,6 +46,10 @@ spec:
           - --use-environment=true
           - -d
           - -l=debug
+          {{- with .Values.env }}
+          env:
+            {{- get (fromYaml (include "thumbor.envVars" $)) "env" | toYaml | nindent 12 -}}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8888

--- a/charts/thumbor/templates/thumbor-deployment.yaml
+++ b/charts/thumbor/templates/thumbor-deployment.yaml
@@ -65,8 +65,16 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
+          {{- if .Values.thumbor_config }}
             - name: thumbor-config
-              mountPath: /conf/thumbor
+              mountPath: /conf/thumbor/thumbor.conf
+              subPath: thumbor.conf
+          {{- end }}
+          {{- if .Values.thumbor_key.manage }}
+            - name: thumbor-key
+              mountPath: /conf/thumbor/thumbor.key
+              subPath: thumbor.key
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -79,7 +87,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{ if or .Values.thumbor_config .Values.thumbor_key.manage -}}
       volumes:
+      {{- if .Values.thumbor_config }}
         - name: thumbor-config
+          configMap:
+            name: {{ include "common.names.fullname" . }}
+      {{- end }}
+      {{- if .Values.thumbor_key.manage }}
+        - name: thumbor-key
           secret:
-            secretName: {{ include "common.secrets.name" (dict "existingSecret" .Values.thumbor_config_existing_secret "defaultNameSuffix" "" "context" $) }}
+            secretName: {{ include "common.secrets.name" (dict "existingSecret" .Values.thumbor_existing_secret "defaultNameSuffix" "" "context" $) }}
+      {{- end }}
+      {{- end -}}

--- a/charts/thumbor/templates/thumbor-deployment.yaml
+++ b/charts/thumbor/templates/thumbor-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 8 }}
         {{- end }}
     spec:
-      {{- include "common.images.renderPullSecrets"  (dict "value" .Values.image "context" $) | nindent 6 }}
+      {{- include "common.images.renderPullSecrets"  (dict "value" .Values.image "context" $) | nindent 6 -}}
       serviceAccountName: {{ include "thumbor.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -45,10 +45,10 @@ spec:
           - --keyfile=/conf/thumbor/thumbor.key
           - --use-environment=true
           - -d
-          - -l=debug
+          - -l=warning
           {{- with .Values.env }}
           env:
-            {{- get (fromYaml (include "thumbor.envVars" $)) "env" | toYaml | nindent 12 -}}
+            {{- get (fromYaml (include "thumbor.envVars" .)) "env" | toYaml | nindent 12 -}}
           {{- end }}
           ports:
             - name: http

--- a/charts/thumbor/templates/thumbor-deployment.yaml
+++ b/charts/thumbor/templates/thumbor-deployment.yaml
@@ -42,7 +42,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --conf=/conf/thumbor/thumbor.conf
+          {{- if .Values.thumbor_key.manage }}
           - --keyfile=/conf/thumbor/thumbor.key
+          {{- end }}
           - --use-environment=true
           - -d
           - -l=warning

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -22,19 +22,17 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-# env: {}
-  # key: value
 
-env:
-  ELASTICSEARCH_PASSWORD:
-    valueFrom:
-      secretKeyRef:
-        name: dd-elastic      
-        key: password
+env: {}
+  # SOME_KEY: SOME_VALUE
+  # SOME_PASSWORD:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: mysecret  
+  #       key: password
 
 securityContext: {}
   # capabilities:
@@ -65,8 +63,7 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources:
-  {}
+resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -111,6 +108,21 @@ remotecv:
 
   podAnnotations: {}
 
+  env:
+    HTTP_SERVER_PORT: "8080"
+    WITH_HEALTHCHECK: "1"
+    # this value needs to be adjusted,
+    # if the release is not called thumbor
+    REDIS_HOST: "thumbor-redis-master"
+    REDIS_PORT: "6379"
+    REDIS_PASSWORD:
+      valueFrom:
+        secretKeyRef:
+          # this value also needs to be adjusted
+          # if the release name changes
+          name: thumbor-redis
+          key: redis-password
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -124,8 +136,7 @@ remotecv:
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
     tag: "3-py-3.11"
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -1,31 +1,36 @@
+# -- how many thumbor pods should be deployed
 replicaCount: 1
 
 image:
-  # Overrides the image
+  # -- Overrides the image
   repository: ghcr.io/thumbor/thumbor
+  # -- override pullPolicy for thumbor image
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion.
   tag: "7-py-3.10"
 
+# -- if the used image is not public
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: false
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- optional pod Annotations
 podAnnotations: {}
 
+# -- optional podSecurityContext settings
 podSecurityContext: {}
   # fsGroup: 2000
 
-
+# -- environment variables for the thumbor pod
 env: {}
   # SOME_KEY: SOME_VALUE
   # SOME_PASSWORD:
@@ -34,6 +39,7 @@ env: {}
   #       name: mysecret  
   #       key: password
 
+# -- securityContext for the thumbor container
 securityContext: {}
   # capabilities:
   #   drop:
@@ -42,21 +48,27 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+# Thumbor service
 service:
+  # -- Thumbor service type
   type: ClusterIP
+  # -- Thumbor service port thumbor uses container Port 80
   port: 80
 
 ingress:
+  # -- enable ingress
   enabled: false
+  # -- specify ingress class or leave blank for the default ingress class
   className: ""
-  annotations:
-    {}
+  # -- ingress annotations
+  annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
         - path: /
+          # -- if errors occure use Prefix
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
@@ -84,9 +96,11 @@ tolerations: []
 
 affinity: {}
 
+# -- configuration file for thumbor
 thumbor_config: |
     AUTO_WEBP = True
 
+# -- if you have already an secret with the thumbor key
 thumbor_existing_secret: ""
 
 thumbor_key:
@@ -98,10 +112,14 @@ redis:
     repository: redis
     tag: "7.0"
   replica:
+    # -- increase this option if you need replicas
     replicaCount: 0
 
 remotecv:
   enabled: true
+
+  # -- set this to false if you want to use an already existing redis server
+  installRedis: true
 
   replicaCount: 1
 

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -84,16 +84,21 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
+  # -- enable autoscaling via the HorizontalPodAutoscaler for the thumbor deployment
+  # Your Cluster needs to support this!
   enabled: false
   minReplicas: 1
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# -- deploy thumbor to a specific node
 nodeSelector: {}
 
+# -- define tolerations for the thumbor pod
 tolerations: []
 
+# -- define affinities for the thumbor pod
 affinity: {}
 
 # -- configuration file for thumbor
@@ -121,8 +126,10 @@ remotecv:
   # -- set this to false if you want to use an already existing redis server
   installRedis: true
 
+  # -- how many remotecv pod do you want
   replicaCount: 1
 
+  # -- add podAnnotations tho the thumbor remotecv pod
   podAnnotations: {}
 
   env:
@@ -141,6 +148,8 @@ remotecv:
           key: redis-password
 
   autoscaling:
+    # -- enable autoscaling via the HorizontalPodAutoscaler for the remotecv deployment
+    # Your Cluster needs to support this!
     enabled: false
     minReplicas: 1
     maxReplicas: 100
@@ -148,10 +157,10 @@ remotecv:
     # targetMemoryUtilizationPercentage: 80
 
   image:
-    # Overrides the image
+    # -- Overrides the remotecv image
     repository: ghcr.io/thumbor/remotecv
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # -- Overrides the image tag whose default is the chart appVersion.
     tag: "3-py-3.11"
   resources: {}
     # limits:
@@ -160,6 +169,11 @@ remotecv:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  # -- deploy thumbor remotecv to a specific node
   nodeSelector: {}
-  affinity: {}
+
+  # -- define tolerations for the thumbor remotecv pod
   tolerations: []
+
+  # -- define affinities for the thumbor remotecv pod
+  affinity: {}

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -13,7 +13,7 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: true
+  create: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -26,8 +26,17 @@ podSecurityContext:
   {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+# env: {}
+  # key: value
+
+env:
+  ELASTICSEARCH_PASSWORD:
+    valueFrom:
+      secretKeyRef:
+        name: dd-elastic      
+        key: password
+
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -108,6 +117,7 @@ remotecv:
     maxReplicas: 100
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+
   image:
     # Overrides the image
     repository: ghcr.io/thumbor/remotecv

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -84,15 +84,10 @@ tolerations: []
 
 affinity: {}
 
-thumbor_config:
-  queued_detector:
-    enabled: true
-    enable_redis: true
-
-  content: |
+thumbor_config: |
     AUTO_WEBP = True
 
-thumbor_config_existing_secret: ""
+thumbor_existing_secret: ""
 
 thumbor_key:
   manage: true
@@ -102,8 +97,12 @@ redis:
     registry: docker.io
     repository: redis
     tag: "7.0"
+  replica:
+    replicaCount: 0
 
 remotecv:
+  enabled: true
+
   replicaCount: 1
 
   podAnnotations: {}

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- override pullPolicy for thumbor image
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "7-py-3.10"
+  tag: "7.7.5-py-3.12"
 
 # -- if the used image is not public
 imagePullSecrets: []

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- override pullPolicy for thumbor image
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "7.7.7-py-3.13"
+  tag: "7.8.0-py-3.14"
 
 # -- if the used image is not public
 imagePullSecrets: []

--- a/charts/thumbor/values.yaml
+++ b/charts/thumbor/values.yaml
@@ -7,7 +7,7 @@ image:
   # -- override pullPolicy for thumbor image
   pullPolicy: IfNotPresent
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "7.7.5-py-3.12"
+  tag: "7.7.7-py-3.13"
 
 # -- if the used image is not public
 imagePullSecrets: []


### PR DESCRIPTION
Hello,

I tested this Helm Chart for our setup and discovered some drawbacks.

## Changes:

### Add support for environment variables
- Add default envs for a simple deployment with the included Redis
- Add a helper to the `_helpers.tpl` to convert the envs from the `value.yaml` to the correct format
- I needed to build a workaround for the remotecv pod. For some reason remotecv does not take the env vars automatically
```yaml
args:
  - "--host=$(REDIS_HOST)"
  - "--port=$(REDIS_PORT)"
  - "--with-healthcheck"
  - "--server-port=$(HTTP_SERVER_PORT)"
  - "--password=$(REDIS_PASSWORD)"
```

### Add initContainer to remotecv
Remotecv requires connection to Redis. If Redis is deployed with this Helm Chart, it is not accessible right from the start.  I added an initContainer which waits until the configured Redis is accessible.

```yaml
initContainers:
  - name: wait-for-redis
    image: busybox
    command:
      - /bin/sh
      - -c
      - >
        COUNT=0
        while [ $(echo -e "AUTH $REDIS_PASSWORD\r\nPING\r\n" | nc $REDIS_HOST $REDIS_PORT | grep -c "PONG") -ne 1 ]; do
          if [[ $COUNT -ge 10 ]]; then
            echo "Waited to long restarting POD"
            exit 1;
          fi

          echo "Waiting for Redis...";
          sleep 1;
          ((COUNT++))
        done
```

This feature should probably be added to the remotecv container.

### Config / values.yaml changes
- move thumbor config in a configmap but keep thumbor.key in the secret
- control Redis and remotecv installation via separate variables (not within the `thumbor_config`)
- scale redis to only the master pod in the default deployment. For small deployments with only one Pod for each component (thumbor, remotecv, redis) it should be enough. It can easily be scaled up again, if replicas are needed (documented variable).

### Comments
- add more documenting comments to the `values.yaml`
- regenerate README.md with helm-docs

### Other
- I have increased the Chart version to 1.0.0 because  of the possible breaking changes (We will be using this Chart in prod).
- I have changed the Markdown Syntax in the top `README.md` according to the linter.

If something is not clear, please ask. I am happy to answer.